### PR TITLE
workflows: all linux platforms

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -15,8 +15,6 @@ jobs:
       pull-requests: write
       packages: write
     uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.1
-    with:
-      buildpro-images: '["rocky8-gcc9"]'
     secrets: inherit
   macos:
     uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.1


### PR DESCRIPTION
* was rocky8-gcc9 only
* now rocky[8|9|10]-gcc[9|13|15]

resolves https://github.com/externpro/externpro/issues/296