### PR TITLE
externpro 25.07.6

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,0 +1,2 @@
+tag: 25.07.1
+message: "externpro version 25.07.1 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -1,10 +1,10 @@
-name: Build
+name: xpBuild
 permissions:
   contents: read
   pull-requests: write
 on:
   push:
-    tags: ["v*"]
+    tags: ["xpv*"]
   pull_request:
     branches: ["xpro"]
   workflow_dispatch:
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.4
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.4
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.4
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
     secrets: inherit

--- a/.github/workflows/xpupdate.yml
+++ b/.github/workflows/xpupdate.yml
@@ -7,8 +7,8 @@ on:
   workflow_dispatch:
 jobs:
   update:
-    uses: externpro/externpro/.github/workflows/update-externpro.yml@main
-    with:
-      create_missing_workflows: false
+    uses: externpro/externpro/.github/workflows/update-externpro.yml@25.07.6
     secrets:
       workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
+    with:
+      create_missing_workflows: false


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.6`

## Changes

- Updated `.devcontainer` to externpro `25.07.6`
- Previous HEAD: `4d4eb80bab76c384644dad41abcba3cfc0e7c926`
- New HEAD: `e07eafd5a3f9d27c4a56ebe5fddc4058b332d436`
- Created `.github/release-tag.yml` (tag: `25.07.1`)
- If you add the \"release:tag\" label, the tag will be \`25.07.1\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/buildpro/blob/externpro-update-25.07.6-21771520433-1/.github/release-tag.yml
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.4 → 25.07.6
✓ xpbuild.yml: workflow name updated from template
✓ xpbuild.yml: push.tags updated from template
✓ xpupdate.yml: Version updated main → 25.07.6

### Preserved Customizations
🔧 create_missing_workflows: false

---

*This PR was created automatically by GitHub Actions*
