### PR TITLE
externpro 25.07.6-3-gb12ee47

### DIFF
--- a/.github/workflows/xpupdate.yml
+++ b/.github/workflows/xpupdate.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   update:
-    uses: externpro/externpro/.github/workflows/update-externpro.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/update-externpro.yml@main
     secrets:
       workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
     with:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.6-3-gb12ee47`

## Changes

- Updated `.devcontainer` to externpro `25.07.6-3-gb12ee47`
- Previous HEAD: `e07eafd5a3f9d27c4a56ebe5fddc4058b332d436`
- New HEAD: `b12ee47630ab0eabbf061790e6358d7162a9038e`
  - Target ref HEAD: `3959245e19bd49e0bb571bd7a7089670c1c330d7`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`25.07.1\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/buildpro/blob/externpro-update-25.07.6-3-gb12ee47-21776097133-1/.github/release-tag.yml
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpupdate.yml: Version updated 25.07.6 → main

### Preserved Customizations
🔧 create_missing_workflows: false

---

*This PR was created automatically by GitHub Actions*
