### PR TITLE
externpro 25.07.7-11-g238e18b

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.7
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.7
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.7
     secrets: inherit


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.7-11-g238e18b`

## Changes

- Updated `.devcontainer` to externpro `25.07.7-11-g238e18b`
- Previous HEAD: `e07acf9191d01a51c9261086aba622e4a4d66743`
- New HEAD: `238e18b4b792633fc7c744f77730d9bf44acc365`
- If you add the \"release:tag\" label, the tag will be \`25.07.1\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/buildpro/blob/externpro-update-25.07.7-11-g238e18b-21936074064-1/.github/release-tag.yml
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.6 → 25.07.7

---

*This PR was created automatically by GitHub Actions*
