### PR TITLE
externpro 25.07.9

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: 25.07.1
-message: "externpro version 25.07.1 tag"
+tag: xpv25.07.1.1
+message: "xpro version 25.07.1.1 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.7
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.9
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.7
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.9
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.7
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.9
     secrets: inherit


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.9`

## Changes

- Updated `.devcontainer` to externpro `25.07.9`
- Previous HEAD: `238e18b4b792633fc7c744f77730d9bf44acc365`
- New HEAD: `7e795da3b9dc06c33332e5044f602c280fddb14e`
- Updated `.github/release-tag.yml` (tag: `xpv25.07.1.1`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.7 → 25.07.9

---

*This PR was created automatically by GitHub Actions*
