### PR TITLE
externpro 25.07.10

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.9
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.10
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.9
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.10
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.9
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.10
     secrets: inherit


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.10`

## Changes

- Updated `.devcontainer` to externpro `25.07.10`
- Previous HEAD: `7e795da3b9dc06c33332e5044f602c280fddb14e`
- New HEAD: `7f7f1539ea83a448d93543f4a9fdb67100c2c702`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

⚠️ xpbuild.yml: Template drift detected (outside preserved customizations)
✓ xpbuild.yml: Version updated 25.07.9 → 25.07.10

---

*This PR was created automatically by GitHub Actions*
