### PR TITLE
externpro 25.07.10-2-g7607b1a

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,12 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.9
-    secrets: inherit
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.10
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.9
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.10
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.9
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.10
     secrets: inherit


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.10-2-g7607b1a`

## Changes

- Updated `.devcontainer` to externpro `25.07.10-2-g7607b1a`
- Previous HEAD: `7e795da3b9dc06c33332e5044f602c280fddb14e`
- New HEAD: `7607b1a2e1a07d1d67b9bdba8f0856cbbd37c858`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.9 → 25.07.10

---

*This PR was created automatically by GitHub Actions*
