### PR TITLE
externpro 25.07.10-4-ga34e03a

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,12 +14,12 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.10
+    uses: externpro/externpro/.github/workflows/build-linux.yml@main
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.10
+    uses: externpro/externpro/.github/workflows/build-macos.yml@main
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.10
+    uses: externpro/externpro/.github/workflows/build-windows.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.10-4-ga34e03a`

## Changes

- Updated `.devcontainer` to externpro `25.07.10-4-ga34e03a`
- Previous HEAD: `7607b1a2e1a07d1d67b9bdba8f0856cbbd37c858`
- New HEAD: `a34e03a298726b5e864d0e4482e273defde64698`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07.10 → main

---

*This PR was created automatically by GitHub Actions*
