### PR TITLE
externpro 25.07.11

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 25.07.1.1 tag",
+  "tag": "xpv25.07.1.1"
+}

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,0 @@
-tag: xpv25.07.1.1
-message: "xpro version 25.07.1.1 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,12 +14,12 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.10
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.11
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.10
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.11
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.10
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.11
     secrets: inherit

--- a/.github/workflows/xpinit.yml
+++ b/.github/workflows/xpinit.yml
@@ -1,0 +1,12 @@
+name: xpInit externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  init:
+    uses: externpro/externpro/.github/workflows/init-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -1,0 +1,44 @@
+name: xpRelease
+on:
+  workflow_dispatch:
+    inputs:
+      workflow_run_url:
+        description: 'URL of the workflow run containing artifacts to upload (e.g., https://github.com/owner/repo/actions/runs/123456789)'
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["xpBuild"]
+    types: [completed]
+jobs:
+  dispatch-at-tag:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'xpv')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      -
+        name: Dispatch xpRelease at tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TAG_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${{ github.repository }}/actions/workflows/xprelease.yml/dispatches" \
+            -f ref="$TAG_REF" \
+            -f inputs[workflow_run_url]="$RUN_URL"
+  # Upload build artifacts as release assets
+  release-from-build:
+    if: github.event_name == 'workflow_dispatch'
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.11
+    with:
+      workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    secrets: inherit

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,0 +1,16 @@
+name: xpTag
+permissions:
+  contents: write
+  issues: write
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.11
+    with:
+      merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.11`

## Changes

- Updated `.devcontainer` to externpro `25.07.11`
- Previous HEAD: `7607b1a2e1a07d1d67b9bdba8f0856cbbd37c858`
- New HEAD: `25faaa8321c47a7904b56c093b0da4180b4b6b98`
- Created `.github/release-tag.json` (tag: `xpv25.07.1.1`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Synced from template
✓ xpinit.yml: Created new workflow from template
✓ xprelease.yml: Created new workflow from template
✓ xptag.yml: Created new workflow from template

---

*This PR was created automatically by GitHub Actions*
