### PR TITLE
externpro 25.07.12

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,12 +14,12 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.11
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.12
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.11
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.12
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.11
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.12
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.11
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.12
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.11
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.12
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.12`

## Changes

- Updated `.devcontainer` to externpro `25.07.12`
- Previous HEAD: `25faaa8321c47a7904b56c093b0da4180b4b6b98`
- New HEAD: `acd4e3dcc3e84d77045ee005d43456cd698dfc2c`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Synced from template
✓ xprelease.yml: Synced from template
✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
