### PR TITLE
externpro 25.07.12-2-g2a6ac05

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -17,6 +17,8 @@ jobs:
     uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.12
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
+    with:
+      buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
     uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.12
     secrets: inherit


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.12-2-g2a6ac05`

## Changes

- Updated `.devcontainer` to externpro `25.07.12-2-g2a6ac05`
- Previous HEAD: `acd4e3dcc3e84d77045ee005d43456cd698dfc2c`
- New HEAD: `2a6ac0569101e29efb352f6131c99555ee3ce220`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

---

*This PR was created automatically by GitHub Actions*
