### PR TITLE
externpro 25.07.12-4-gbbb74c6

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,14 +14,14 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.12
+    uses: externpro/externpro/.github/workflows/build-linux.yml@main
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
-    with:
-      buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
     uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.12
     secrets: inherit
   windows:
     uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.12
     secrets: inherit
+    with:
+      buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.12-4-gbbb74c6`

## Changes

- Updated `.devcontainer` to externpro `25.07.12-4-gbbb74c6`
- Previous HEAD: `acd4e3dcc3e84d77045ee005d43456cd698dfc2c`
- New HEAD: `bbb74c69bfb2063e71e22153ce274e2225a62cf8`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

🔧 xpbuild.yml: preserved with block jobs.linux.with
✓ xpbuild.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
