### PR TITLE
externpro 25.07.12-5-g1e9532a

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.12
-    secrets:
-      automation_token: ${{ secrets.GHCR_TOKEN }}
+    uses: externpro/externpro/.github/workflows/build-linux.yml@main
     with:
       buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
   macos:
     uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.12
     secrets: inherit


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.12-5-g1e9532a`

## Changes

- Updated `.devcontainer` to externpro `25.07.12-5-g1e9532a`
- Previous HEAD: `acd4e3dcc3e84d77045ee005d43456cd698dfc2c`
- New HEAD: `1e9532a7c0e30c420c344a84e3b9c69d95f8575c`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

🔧 xpbuild.yml: preserved with block jobs.linux.with
✓ xpbuild.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
