### PR TITLE
externpro 25.07.13

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,14 +14,14 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.12
-    secrets:
-      automation_token: ${{ secrets.GHCR_TOKEN }}
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.13
     with:
       buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.12
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.13
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.12
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.13
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.12
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.13
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.12
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.13
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.13`

## Changes

- Updated `.devcontainer` to externpro `25.07.13`
- Previous HEAD: `acd4e3dcc3e84d77045ee005d43456cd698dfc2c`
- New HEAD: `dd8ede8150899bef4c6deb5babed1c0fcdcf37ca`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

🔧 xpbuild.yml: preserved `with` block `jobs.linux.with`
✓ xpbuild.yml: Synced from template
✓ xprelease.yml: Synced from template
✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
