### PR TITLE
externpro 25.07.15-3-g0c4d2ac

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,14 +14,15 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.13
-    with:
-      buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.15
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
+    with:
+      buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.13
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.15
     secrets: inherit
+    with: {}
   windows:
     uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.15
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.13
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.15
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.13
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.15
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/xpupdate.yml
+++ b/.github/workflows/xpupdate.yml
@@ -10,3 +10,4 @@ jobs:
     uses: externpro/externpro/.github/workflows/update-externpro.yml@main
     secrets:
       automation_token: ${{ secrets.XPRO_TOKEN }}
+    with: {}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,6 +3,7 @@
   "include": [
     ".devcontainer/cmake/presets/xpLinuxNinja.json",
     ".devcontainer/cmake/presets/xpDarwinNinja.json",
-    ".devcontainer/cmake/presets/xpWindowsVs2022.json"
+    ".devcontainer/cmake/presets/xpMswVs2022.json",
+    ".devcontainer/cmake/presets/xpMswVs2026.json"
   ]
 }


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.15-3-g0c4d2ac`

## Changes

- Updated `.devcontainer` to externpro `25.07.15-3-g0c4d2ac`
- Previous HEAD: `dd8ede8150899bef4c6deb5babed1c0fcdcf37ca`
- New HEAD: `0c4d2acfeea7681c47cf33ca036802882f27704c`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates
- CMakePresets.json review needed
  - See details below

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.vs_compilers`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template
- ✓ xpupdate.yml: Synced from template

### CMakePresets.json

- Auto-fix: replaced `.devcontainer/cmake/presets/xpWindowsVs2022.json` include and staged `CMakePresets.json`

---

*This PR was created automatically by GitHub Actions*
