### PR TITLE
externpro 25.07.17-30-g1a9ebb0

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,17 +14,17 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-linux.yml@main
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
       buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-macos.yml@main
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-windows.yml@main
     secrets: inherit
     with:
       vs_compilers: '["Vs2022"]'

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.17-30-g1a9ebb0`

## Changes

- Updated `.devcontainer` to externpro `25.07.17-30-g1a9ebb0`
- Previous HEAD: `65da9ad82454c0b3e4905998cd46452e6de95c18`
- New HEAD: `1a9ebb0cd853350995b9604745863a3947b80131`
  - Target ref HEAD: `b99d8d0b1e725c3d56c769a8b621e043ecd19250`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.vs_compilers`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
