### PR TITLE
externpro 25.07.18-17-gcf054a4

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,17 +14,17 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.18
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
       buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.18
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.18
     secrets: inherit
     with:
       vs_compilers: '["Vs2022"]'

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.18
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.17
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.18
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,8 @@ get_cmake_property(pros VARIABLES)
 # xp_ variables from pros.cmake, included by xproinc.cmake
 list(FILTER pros INCLUDE REGEX "^xp_")
 list(SORT pros)
-list(REMOVE_ITEM pros xp_googletest)
-list(PREPEND pros xp_googletest) # make googetest be first
+list(REMOVE_ITEM pros xp_googletest xp_Threads)
+list(PREPEND pros xp_Threads xp_googletest) # make Threads and googletest first
 find_program(XVFB_RUN_EXEC xvfb-run)
 if(XVFB_RUN_EXEC)
   set(xvfb_cmd ${XVFB_RUN_EXEC})

--- a/test/spatialite-tools/CMakeLists.txt
+++ b/test/spatialite-tools/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach(tool ${tools})
 endforeach()
 # spatialite_spatial_query test
 find_program(SPATIALITE_TOOL spatialite
-  PATHS "${xpuse-spatialite-tools_DIR}/../../bin"
+  PATHS "${spatialite-tools_DIR}/../../bin"
   NO_DEFAULT_PATH
   )
 if(NOT SPATIALITE_TOOL)

--- a/test/wxinclude.cmake
+++ b/test/wxinclude.cmake
@@ -1,4 +1,4 @@
-set(pro wxinclude)
+set(pro wxInclude)
 set(cmd "${${pro}_EXE} --version")
 execute_process(COMMAND bash -c "${cmd} 2>&1 | head -n 3"
   ERROR_VARIABLE ${pro}_err ERROR_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.18-17-gcf054a4`

## Changes

- Updated `.devcontainer` to externpro `25.07.18-17-gcf054a4`
- Previous HEAD: `65da9ad82454c0b3e4905998cd46452e6de95c18`
- New HEAD: `cf054a4d69edb1a88f5d4ee9354d1a57798a7081`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.vs_compilers`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
