### PR TITLE
externpro 25.07.18-21-g0c316b4

### DIFF
--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -4,7 +4,10 @@
     {
       "name": "config-base",
       "hidden": true,
-      "binaryDir": "${sourceDir}/_bld-${presetName}"
+      "binaryDir": "${sourceDir}/_bld-${presetName}",
+      "cacheVariables": {
+        "FIND_PACKAGE_CMAKE_SCRIPT": "ON"
+      }
     }
   ],
   "buildPresets": [

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -34,10 +34,10 @@ foreach(pro ${pros})
     # compilation terminated.
     continue()
   endif()
-  if(pro STREQUAL ffmpeg)
+  if(pro STREQUAL FFmpeg)
     xpGetPkgVar(FFmpeg DLLS) # sets FFmpeg_DLLS
     if(DEFINED FFmpeg_DLLS)
-      set(ffmpeg_postBuildCopy ${FFmpeg_DLLS})
+      set(FFmpeg_postBuildCopy ${FFmpeg_DLLS})
     endif()
   endif()
   if(pro STREQUAL geotranz)


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.18-21-g0c316b4`

## Changes

- Updated `.devcontainer` to externpro `25.07.18-21-g0c316b4`
- Previous HEAD: `cf054a4d69edb1a88f5d4ee9354d1a57798a7081`
- New HEAD: `0c316b415584aa56ddf1984939ad8fa116a8425c`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.vs_compilers`

---

*This PR was created automatically by GitHub Actions*
