### PR TITLE
externpro 25.07.19

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,17 +14,17 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.19
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
       buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.19
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.19
     secrets: inherit
     with:
       vs_compilers: '["Vs2022"]'

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.19
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.18
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.19
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.19`

## Changes

- Updated `.devcontainer` to externpro `25.07.19`
- Previous HEAD: `0c316b415584aa56ddf1984939ad8fa116a8425c`
- New HEAD: `8144b051461a0e4db91872b8941176dcf9bf864c`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.vs_compilers`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
