### PR TITLE
externpro 26.01-5-g1fe6cf5

### DIFF
--- a/CMakePresetsBase.json
+++ b/CMakePresetsBase.json
@@ -4,10 +4,7 @@
     {
       "name": "config-base",
       "hidden": true,
-      "binaryDir": "${sourceDir}/_bld-${presetName}",
-      "cacheVariables": {
-        "FIND_PACKAGE_CMAKE_SCRIPT": "ON"
-      }
+      "binaryDir": "${sourceDir}/_bld-${presetName}"
     }
   ],
   "buildPresets": [


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01-5-g1fe6cf5`

## Changes

- Updated `.devcontainer` to externpro `26.01-5-g1fe6cf5`
- Previous HEAD: `b7c3344436ea6f12e58a05af2dcab337addf3174`
- New HEAD: `1fe6cf59a332589ea02b4610a8c2964156363245`
  - Target ref HEAD: `be9da67384b1344684b335822f7ebad9cb7c23a0`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.vs_compilers`

---

*This PR was created automatically by GitHub Actions*
