### PR TITLE
externpro 26.01-8-g4e58464

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -26,5 +26,4 @@ jobs:
   windows:
     uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
     secrets: inherit
-    with:
-      vs_compilers: '["Vs2022"]'
+    with: {}


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01-8-g4e58464`

## Changes

- Updated `.devcontainer` to externpro `26.01-8-g4e58464`
- Previous HEAD: `1fe6cf59a332589ea02b4610a8c2964156363245`
- New HEAD: `4e584645c039b55c808140a9fbd42b0df57a09c5`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
