### PR TITLE
externpro 26.01-10-g715cd0c

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -24,6 +24,6 @@ jobs:
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
+    uses: externpro/externpro/.github/workflows/build-windows.yml@main
     secrets: inherit
     with: {}

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -26,5 +26,4 @@ jobs:
   windows:
     uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
     secrets: inherit
-    with:
-      vs_compilers: '["Vs2022"]'
+    with: {}


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01-10-g715cd0c`

## Changes

- Updated `.devcontainer` to externpro `26.01-10-g715cd0c`
- Previous HEAD: `1fe6cf59a332589ea02b4610a8c2964156363245`
- New HEAD: `715cd0c85a321d255990ea00c4d599debe0f9bdb`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated caller workflows to match templates

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- ✓ xpbuild.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
