### PR TITLE
externpro 26.01-16-gdc0af7c

### DIFF
--- a/.github/workflows/system-info.yml
+++ b/.github/workflows/system-info.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       -
         name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Runner Information
         id: runner-info

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -26,5 +26,4 @@ jobs:
   windows:
     uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
     secrets: inherit
-    with:
-      vs_compilers: '["Vs2022"]'
+    with: {}

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -26,4 +26,5 @@ jobs:
   windows:
     uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
     secrets: inherit
-    with: {}
+    with:
+      enable_tmate: true

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -26,5 +26,4 @@ jobs:
   windows:
     uses: externpro/externpro/.github/workflows/build-windows.yml@26.01
     secrets: inherit
-    with:
-      enable_tmate: true
+    with: {}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -76,7 +76,9 @@ foreach(pro ${pros})
       target_compile_definitions(${pro}_test PRIVATE ${${pro}_compile_definitions})
       list(APPEND all_compile_definitions ${${pro}_compile_definitions})
     endif()
-    if(pro STREQUAL "wxx" AND XVFB_RUN_EXEC)
+    if(pro STREQUAL "wxx" AND MSVC_VERSION VERSION_EQUAL 1950)
+      message(STATUS "Skipping wxx_test on VS2026 (MSVC_VERSION 1950) due to known hang issue")
+    elseif(pro STREQUAL "wxx" AND XVFB_RUN_EXEC)
       add_test(NAME ${pro}_test COMMAND ${XVFB_RUN_EXEC} -a
         --server-args=-screen\ 0\ 1920x1080x24\ -nolisten\ tcp
         $<TARGET_FILE:${pro}_test>


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01-16-gdc0af7c`

## Changes

- Updated `.devcontainer` to externpro `26.01-16-gdc0af7c`
- Previous HEAD: `1fe6cf59a332589ea02b4610a8c2964156363245`
- New HEAD: `dc0af7c2f73160297213a5b97bc1696969f228d0`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
