### PR TITLE
externpro 26.01.1-26-gd73bea1

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,8 @@ get_cmake_property(pros VARIABLES)
 # xp_ variables from pros.cmake, included by xproinc.cmake
 list(FILTER pros INCLUDE REGEX "^xp_")
 list(SORT pros)
-list(REMOVE_ITEM pros xp_googletest xp_Threads)
-list(PREPEND pros xp_Threads xp_googletest) # make Threads and googletest first
+list(REMOVE_ITEM pros xp_googletest)
+list(PREPEND pros xp_googletest) # make googletest first
 find_program(XVFB_RUN_EXEC xvfb-run)
 if(XVFB_RUN_EXEC)
   set(xvfb_cmd ${XVFB_RUN_EXEC})


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-26-gd73bea1`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-26-gd73bea1`
- Previous HEAD: `e3220ab439d4475eb9bb6b9a9c84919ba63d095e`
- New HEAD: `d73bea1bfc60c5b8d1ea176ba212138623d7b4a3`
  - Target ref HEAD: `33289c0fc0957e51c3b7d8351f5757bcb01edbd1`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
