### PR TITLE
externpro 26.01.1-28-ga16d3d9

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,8 +3,8 @@ get_cmake_property(pros VARIABLES)
 # xp_ variables from pros.cmake, included by xproinc.cmake
 list(FILTER pros INCLUDE REGEX "^xp_")
 list(SORT pros)
-list(REMOVE_ITEM pros xp_googletest xp_Threads)
-list(PREPEND pros xp_Threads xp_googletest) # make Threads and googletest first
+list(REMOVE_ITEM pros xp_googletest)
+list(PREPEND pros xp_googletest) # make googletest first
 find_program(XVFB_RUN_EXEC xvfb-run)
 if(XVFB_RUN_EXEC)
   set(xvfb_cmd ${XVFB_RUN_EXEC})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -79,7 +79,7 @@ foreach(pro ${pros})
       target_compile_definitions(${pro}_test PRIVATE ${${pro}_compile_definitions})
       list(APPEND all_compile_definitions ${${pro}_compile_definitions})
     endif()
-    if(pro STREQUAL "wxx" AND MSVC_VERSION VERSION_EQUAL 1950)
+    if(pro STREQUAL "wxx" AND MSVC_VERSION VERSION_GREATER_EQUAL 1950)
       message(STATUS "Skipping wxx_test on VS2026 (MSVC_VERSION 1950) due to known hang issue")
     elseif(pro STREQUAL "wxx" AND XVFB_RUN_EXEC)
       add_test(NAME ${pro}_test COMMAND ${XVFB_RUN_EXEC} -a


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-28-ga16d3d9`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-28-ga16d3d9`
- Previous HEAD: `e3220ab439d4475eb9bb6b9a9c84919ba63d095e`
- New HEAD: `a16d3d9b36c91d09d247bb6d1392b5ec007031d6`
  - Target ref HEAD: `ed72bce0e46a4e40e6fd8e53b05e77a8a4f8581f`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
