### PR TITLE
externpro 26.01.1-40-g53e567a

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,7 +11,6 @@ if(XVFB_RUN_EXEC)
 endif()
 # NOTE: set ${pro}_libs if ${PRJ}_LIBRARIES isn't sufficient
 set(boost_libs Boost::filesystem Boost::program_options Boost::regex)
-set(boost_compile_definitions "BOOST_NO_CXX98_FUNCTION_BASE")
 set(hdf5_libs xpro::hdf5_cpp-static)
 set(libgeotiff_libs xpro::libgeotiff Boost::filesystem)
 set(libgit2_libs xpro::git2 Boost::filesystem)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,7 @@ list(FILTER pros INCLUDE REGEX "^xp_")
 list(SORT pros)
 list(REMOVE_ITEM pros xp_googletest)
 list(PREPEND pros xp_googletest) # make googletest first
+list(REMOVE_ITEM pros xp_azmq) # TODO: azmq has issues with boost 1.91.0
 find_program(XVFB_RUN_EXEC xvfb-run)
 if(XVFB_RUN_EXEC)
   set(xvfb_cmd ${XVFB_RUN_EXEC})


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-40-g53e567a`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-40-g53e567a`
- Previous HEAD: `a7f47fb381f99a5f6c7bd037378be18e9cf30d1a`
- New HEAD: `53e567a60ac5cfbf33da744d96b7e708061ff58b`
  - Target ref HEAD: `b96ddecb4c46150f2ff6b6806553f66adba9206f`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
