### PR TITLE
externpro 26.01.1-49-g8c08f0b

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,7 +12,7 @@ if(XVFB_RUN_EXEC)
 endif()
 # NOTE: set ${pro}_libs if ${PRJ}_LIBRARIES isn't sufficient
 set(boost_libs Boost::filesystem Boost::program_options Boost::regex)
-set(hdf5_libs xpro::hdf5_cpp-static)
+set(hdf5_libs hdf5::hdf5_cpp-static)
 set(libgeotiff_libs xpro::libgeotiff Boost::filesystem)
 set(libgit2_libs xpro::git2 Boost::filesystem)
 set(libiconv_libs xpro::libiconv)


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-49-g8c08f0b`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-49-g8c08f0b`
- Previous HEAD: `0e352b953871074477bdddbd9cc0cf1b5c4d6b9d`
- New HEAD: `8c08f0bbbcff882a932fd81552aa161a829fff15`
  - Target ref HEAD: `7608cccf5ed289eca02bddde811144401e7114af`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
