### PR TITLE
externpro 26.01.1-56-g8c1588f

### DIFF
--- a/init/pros
+++ b/init/pros
@@ -18,6 +18,7 @@ REPOS="
   ${GITHUB}/externpro/curl
   ${GITHUB}/externpro/duckdb
   ${GITHUB}/externpro/eigen
+  ${GITHUB}/externpro/externpro.wiki
   ${GITHUB}/externpro/fecpp
   ${GITHUB}/externpro/FFmpeg
   ${GITHUB}/externpro/flatbuffers

--- a/init/pros
+++ b/init/pros
@@ -1,3 +1,6 @@
+# manually clone .github repo
+# git clone https://github.com/externpro/.github _dotgithub
+# so it's not in a "hidden" folder
 GITHUB="https://github.com"
 REPOS="
   ${GITHUB}/externpro/activemq-cpp
@@ -22,7 +25,6 @@ REPOS="
   ${GITHUB}/externpro/gdal
   ${GITHUB}/externpro/geos
   ${GITHUB}/externpro/geotranz
-  ${GITHUB}/externpro/.github
   ${GITHUB}/externpro/glew
   ${GITHUB}/externpro/googletest
   ${GITHUB}/externpro/hdf5


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-56-g8c1588f`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-56-g8c1588f`
- Previous HEAD: `5a9747edc363b70de6700c140cb3eb58a8aa919c`
- New HEAD: `8c1588fb6fcb3691cbf6d27ff7a3bb2b0b0290ad`
  - Target ref HEAD: `17b40969fee961d0bb315e38e140b411d1b99acc`
- Updated externpro submodule dependency artifacts (pushed to `main`)
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
