### PR TITLE
externpro 26.01.2-27-g03a451e sync

### DIFF
--- a/test/geos.cpp
+++ b/test/geos.cpp
@@ -8,11 +8,11 @@
 class GEOSHandle
 {
 public:
-  GEOSHandle() : handle(initGEOS_r(nullptr, nullptr)) { }
+  GEOSHandle() : handle(GEOS_init_r()) { }
   ~GEOSHandle()
   {
     if (handle)
-      finishGEOS_r(handle);
+      GEOS_finish_r(handle);
   }
   GEOSContextHandle_t get() const { return handle; }
 

--- a/test/spatialite-tools/CMakeLists.txt
+++ b/test/spatialite-tools/CMakeLists.txt
@@ -11,7 +11,7 @@ set(tools
   exif_loader
   )
 foreach(tool ${tools})
-  set(tool_EXE $<TARGET_FILE:xpro::${tool}>)
+  set(tool_EXE $<TARGET_FILE:spatialite-tools::${tool}>)
   set(tool_CMAKE ${CMAKE_CURRENT_BINARY_DIR}/${tool}.cmake)
   configure_file(tool.in.cmake ${tool_CMAKE} @ONLY)
   file(GENERATE OUTPUT ${tool_CMAKE} INPUT ${tool_CMAKE})


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.2-27-g03a451e`

## Changes

- Updated `.devcontainer` to externpro `26.01.2-27-g03a451e`
- Previous HEAD: `fbc0062b22e0dafbe65e24f5669c22621f516f42`
- New HEAD: `03a451e89d3d72c0b538639a92282ef042bd543b`
  - Target ref HEAD: `34e0926c1f3f9477515ce75e6e3d7be4e6e1f7e5`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated externpro submodule dependency artifacts (pushed to `main`)

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
