### PR TITLE
externpro 26.01.4 sync

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,16 +14,16 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.3
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.4
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
       buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.3
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.4
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.3
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.4
     secrets: inherit
     with: {}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.3
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.4
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.3
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.4
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.4`

## Changes

- Updated `.devcontainer` to externpro `26.01.4`
- Previous HEAD: `3db763a9f0fe631a916601e36d1a9374c1bb1a75`
- New HEAD: `57da77567f34e53d8d8677938c3bf9c24f736d26`
- Updated caller workflows to match templates
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
