### PR TITLE
externpro 26.01.4-15-g452b054 sync

### DIFF
--- a/test/node-addon-api/CMakeLists.txt
+++ b/test/node-addon-api/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(pro node-addon-api)
 set(tgt ${pro}_test)
 add_library(${tgt} SHARED ${pro}.cpp)
-target_link_libraries(${tgt} PRIVATE xpro::node-addon-api googletest)
+target_link_libraries(${tgt} PRIVATE node-addon-api googletest)
 set_target_properties(${tgt} PROPERTIES OUTPUT_NAME "${tgt}" PREFIX "" SUFFIX ".node")
 if(APPLE)
   target_link_options(${tgt} PUBLIC -undefined dynamic_lookup)

--- a/test/nodexp/CMakeLists.txt
+++ b/test/nodexp/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(pro nodexp)
 set(tgt ${pro}_test)
 add_library(${tgt} SHARED ${pro}.cpp)
-target_link_libraries(${tgt} PRIVATE xpro::node googletest)
+target_link_libraries(${tgt} PRIVATE nodexp::node googletest)
 set_target_properties(${tgt} PROPERTIES OUTPUT_NAME "${tgt}" PREFIX "" SUFFIX ".node")
 if(APPLE)
   target_link_options(${tgt} PUBLIC -undefined dynamic_lookup)


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.4-15-g452b054`

## Changes

- Updated `.devcontainer` to externpro `26.01.4-15-g452b054`
- Previous HEAD: `1d6bbc45ba24a59213a989779fb44170ee5e9ff0`
- New HEAD: `452b05476534796420148e078fa2136e2dc81a94`
  - Target ref HEAD: `6bc7a046cb97d1a728d09fb23f92ec503117b462`
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated externpro submodule dependency artifacts (pushed to `main`)

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`

---

*This PR was created automatically by GitHub Actions*
