### PR TITLE
externpro 26.01.5-7-g64a1663 sync

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,16 +14,16 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.4
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.5
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
       buildpro_images: '["rocky8-gcc9","rocky9-gcc13","rocky10-gcc15","ubuntu"]'
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.4
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.5
     secrets: inherit
     with: {}
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.4
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.5
     secrets: inherit
     with: {}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.4
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.5
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.4
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.5
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/test/FFmpeg.cpp
+++ b/test/FFmpeg.cpp
@@ -24,9 +24,13 @@ protected:
   static void SetUpTestSuite()
   {
     // Initialize FFmpeg libraries once before any tests run
+#if LIBAVFORMAT_VERSION_MAJOR < 58
     av_register_all();
+#endif
     avformat_network_init();
+#if LIBAVFILTER_VERSION_MAJOR < 7
     avfilter_register_all();
+#endif
     avdevice_register_all();
   }
 
@@ -68,8 +72,14 @@ TEST_F(FFmpegTest, CodecSupport)
 // Test case for AVFormat functionality
 TEST_F(FFmpegTest, FormatSupport)
 {
-  // Check format support using the older API
+  // Check format support using the appropriate API for this FFmpeg version
+#if LIBAVFORMAT_VERSION_MAJOR < 58
   AVInputFormat* input_format = av_iformat_next(nullptr);
+#else
+  const AVInputFormat* input_format = nullptr;
+  void* iter = nullptr;
+  input_format = av_demuxer_iterate(&iter);
+#endif
   EXPECT_NE(input_format, nullptr) << "No input formats found";
 
   // Check if common formats are supported
@@ -80,8 +90,10 @@ TEST_F(FFmpegTest, FormatSupport)
 // Test case for AVFilter functionality
 TEST_F(FFmpegTest, FilterSupport)
 {
-  // Initialize filter system
+  // Initialize filter system if required by this FFmpeg version
+#if LIBAVFILTER_VERSION_MAJOR < 7
   avfilter_register_all();
+#endif
 
   // Check if common filters are available
   const AVFilter* scale_filter = avfilter_get_by_name("scale");


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.5-7-g64a1663`

## Changes

- Updated `.devcontainer` to externpro `26.01.5-7-g64a1663`
- Previous HEAD: `d3bf4b035c7629ef0ab36ea0d9437b7c12937bb3`
- New HEAD: `64a1663b4a48cadfbcf0e3e06f699041e38613d8`
  - Target ref HEAD: `38500481ffe300780a5e190031b68cb6783cfd4b`
- Updated caller workflows to match templates
- If you add the \"release:tag\" label, the tag will be \`xpv25.07.1.1\`
- Updated externpro submodule dependency artifacts (pushed to `main`)

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.buildpro_images`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
